### PR TITLE
Fixes for lastet versions of PyTorch

### DIFF
--- a/Model/dataset.py
+++ b/Model/dataset.py
@@ -98,7 +98,7 @@ class TrafficLightDataset(Dataset):
         #image = transforms.functional.normalize(image, mean = [120.56737612047593, 119.16664454573734, 113.84554638827127], std=[66.32028460114392, 65.09469952002551, 65.67726614496246])
         
         image = np.transpose(image, (2, 0, 1))
-        points = torch.tensor(points)
+        points = torch.FloatTensor(points)
         
         #combine all the info into a dictionary
         final_label = {'image': image, 'mode':light_mode, 'points': points, 'block': block}


### PR DESCRIPTION
When I tried to train the model, I have this exception:
~~~~
Traceback (most recent call last):
  File "ImVisible-master/Model/training.py", line 94, in <module>
    loss.backward()
  File "/usr/local/lib/python3.7/dist-packages/torch/_tensor.py", line 307, in backward
    torch.autograd.backward(self, gradient, retain_graph, create_graph, inputs=inputs)
  File "/usr/local/lib/python3.7/dist-packages/torch/autograd/__init__.py", line 156, in backward
    allow_unreachable=True, accumulate_grad=True)  # allow_unreachable flag
RuntimeError: Found dtype Double but expected Float
~~~~
So I found out that points tensor isn't Double. I think this change solved the error.